### PR TITLE
fixed issue with pushgateway pod port in service definition

### DIFF
--- a/prometheus-pushgateway/pushgateway.libsonnet
+++ b/prometheus-pushgateway/pushgateway.libsonnet
@@ -51,7 +51,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local service = k.core.v1.service;
       local servicePort = k.core.v1.service.mixin.spec.portsType;
 
-      local pushgatewayPort = servicePort.newNamed('http', $._config.pushgateway.port, 'http');
+      local pushgatewayPort = servicePort.newNamed('http', $._config.pushgateway.port, 'metrics');
 
       service.new($._config.pushgateway.name, $.pushgateway.deployment.spec.selector.matchLabels, pushgatewayPort) +
       service.mixin.metadata.withNamespace($._config.namespace) +


### PR DESCRIPTION
Currently the endpoint object prometheus-pushgateway is empty because the service spec is not matching any pods. I've updated the port to "metrics" in service spec to fix this issue.

fixes #1 