### PR TITLE
Small Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+GOPATH?=$(HOME)/go
+BIN_DIR=$(GOPATH)/bin
+export PATH:=$(BIN_DIR):$(PATH)
+
 init: jb
 	cd prometheus-pushgateway && jb install
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ init: jb
 
 jb:
 	@echo -e "\033[1m>> Ensuring jb (jsonnet-bundler) is installed\033[0m"
-	go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb	
+	go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 
 gojsontoyaml:
 	@echo -e "\033[1m>> Ensuring gojsontoyaml is installed\033[0m"
@@ -13,13 +13,12 @@ createFolders:
 	rm -rf manifests
 	mkdir manifests
 
-generateJson: 
-	$(MAKE) init
+generateJson: init
 	jsonnet -J prometheus-pushgateway/vendor -J . example.jsonnet
 
-generateYaml:
-	$(MAKE) init
-	$(MAKE) gojsontoyaml
-	$(MAKE) createFolders
+generateYaml: init gojsontoyaml createFolders
 	jsonnet -J prometheus-pushgateway/vendor  -m manifests example.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
 	cat manifests/*
+
+deploy: generateYaml
+	kubectl apply -f manifests/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Simply run:
 $ jsonnet -J vendor example.jsonnet
 ```
 
+## Quickstart
+This quickstart requires the kube-prometheus to already be deployed and the go module path($GOPATH/bin) to be a part of $PART.
+
+Running this one command then should be enough:
+
+```bash
+make deploy
+```
+
 ## Generate Yamls (Similar to the way kube-prometheus works)
 ```bash
 go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ $ jsonnet -J vendor example.jsonnet
 ```
 
 ## Quickstart
-This quickstart requires the kube-prometheus to already be deployed and the go module path($GOPATH/bin) to be a part of $PART.
+This quickstart requires the kube-prometheus to already be deployed and running.
 
-Running this one command then should be enough:
+Running this one command should then be enough:
 
 ```bash
 make deploy


### PR DESCRIPTION
This PR makes some small Makefile convenience improvements
## Changes
 * Add go path to PATH environment variable to in the Makefile(doesn't affect the shell running make)
 * Add a make deploy target to automatically deploy the generated manifests, matching the kube-prometheus one
 * Add a quickstart section to the README using said deploy target
 * Change make targets to depend on required targets rather then running make again