### PR TITLE
Allow cluster external access to the pushgateway

### DIFF
--- a/prometheus-pushgateway/pushgateway.libsonnet
+++ b/prometheus-pushgateway/pushgateway.libsonnet
@@ -56,7 +56,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       service.new($._config.pushgateway.name, $.pushgateway.deployment.spec.selector.matchLabels, pushgatewayPort) +
       service.mixin.metadata.withNamespace($._config.namespace) +
       service.mixin.metadata.withLabels($._config.pushgateway.labels) +
-      service.mixin.spec.withType('ClusterIP'),
+      service.mixin.spec.withType('LoadBalancer'),
 
     serviceMonitor:
       {

--- a/prometheus-pushgateway/pushgateway.libsonnet
+++ b/prometheus-pushgateway/pushgateway.libsonnet
@@ -5,7 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     namespace: 'pushgateway',
 
     versions+:: {
-      pushgateway: 'v1.2.0',
+      pushgateway: 'v1.4.2',
     },
 
     imageRepos+:: {


### PR DESCRIPTION
Services that have to push data for one reason or another are in my opinion likely to be cluster external, so I think allowing cluster external services to access to pushgateway by default makes sense imo.
Though this is of course a security risk to some extent, so I would understand not wanting this change.
# Changes
 * Change service type to LoadBalancer to allow cluster external services to push data
 * Update pushgateway to version 1.4.2