### PR TITLE
Update pushgateway from 1.2.0 to 1.4.2

### DIFF
--- a/prometheus-pushgateway/pushgateway.libsonnet
+++ b/prometheus-pushgateway/pushgateway.libsonnet
@@ -5,7 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     namespace: 'pushgateway',
 
     versions+:: {
-      pushgateway: 'v1.2.0',
+      pushgateway: 'v1.4.2',
     },
 
     imageRepos+:: {


### PR DESCRIPTION
The title says it all, this PR updated prometheus-pushgateway from version 1.2.0 to version 1.4.2.